### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
 {% set name = "google-crc32c" %}
-{% set version = "1.5.0" %}
+{% set version = "1.6.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/googleapis/python-crc32c/archive/v{{ version }}.tar.gz
-  sha256: 029111b916bf130d9bcb13ad81d592e66623713f7791dd6d2bf366afd15dacf6
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/google_crc32c-{{ version }}.tar.gz
+  sha256: 6eceb6ad197656a1ff49ebfbbfa870678c75be4344feb35ac1edf694309413dc
 build:
-  number: 1
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   build:
@@ -23,6 +23,7 @@ requirements:
     - wheel
   run:
     - python
+    - importlib-resources >=1.3 # [py<39]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://github.com/googleapis/python-crc32c/archive/v{{ version }}.tar.gz
   sha256: 029111b916bf130d9bcb13ad81d592e66623713f7791dd6d2bf366afd15dacf6
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

Update to 1.6.0
https://github.com/googleapis/python-crc32c/tree/v1.6.0