### PR TITLE
Update version to 1.8.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,22 @@
 {% set name = "google-crc32c" %}
-{% set version = "1.6.0" %}
+{% set version = "1.8.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/google_crc32c-{{ version }}.tar.gz
-  sha256: 6eceb6ad197656a1ff49ebfbbfa870678c75be4344feb35ac1edf694309413dc
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79
+
 build:
   number: 0
+  skip: true # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
   host:
     - python
@@ -44,9 +47,8 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  licenes_url: https://github.com/googleapis/python-crc32c/blob/main/LICENSE
+  license_url: https://github.com/googleapis/python-crc32c/blob/main/LICENSE
   summary: Python wrapper for a hardware-based implementation of the CRC32C hashing algorithm
-
   description: |
     google-crc32c wraps the libcrc32c
     <https://github.com/google/crc32c> package, which is a hardware-based


### PR DESCRIPTION
google-crc32c 1.8.0

**Destination channel:** defaults

### Links

- [PKG-11441](https://anaconda.atlassian.net/browse/PKG-11441) 
- [Upstream repository](https://github.com/googleapis/python-crc32c)

### Explanation of changes:

- New version number


[PKG-11441]: https://anaconda.atlassian.net/browse/PKG-11441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ